### PR TITLE
Companion bill popup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -60,6 +60,23 @@
 
                           </div>
                         </div>
+                      </div>
+
+                      <div class="modal fade" id="compBillModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+                        <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
+                          <div class="modal-content">
+                            <div class="modal-header">
+                              <h5 class="modal-title" id="exampleModalLongTitle">Modal title</h5>
+                              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+                                
+                              </button>
+                            </div>
+                            <div class="modal-body" id="companionBill">
+                            </div>
+
+                          </div>
+                        </div>
+                      </div>
               <!-- PFAS Project Lab -->
               <li class="navbar">
                 <a class="nav-link" style="color: rgb(84, 84, 84)" href="https://pfasproject.com" target="_blank">PFAS Project Lab</a> 
@@ -320,8 +337,8 @@
                               </a> 
                               <div id='collapseThree${values.ID}' class='collapse' data-parent='#accordion${values.ID}'> 
                                 <div class='card-body'>
-                                  ${values.CompanionBills}
-                              </div> 
+                                  ${values.CompanionBills == 'N/A' ? 'N/A':`<p><a class='compBill' href='#compBillModal' data-bs-toggle='modal'>${values.CompanionBills}</a></p>`}
+                              </div>
                             </div> 
                             <!--PFAS Definition--> 
                             <div class='card'> 
@@ -408,13 +425,29 @@
       });
       $('#basicSearch').on("submit", function(e) { 
         e.preventDefault();
-        dataList.search($('#searchTerm').val(),['Title','Summary','AgenciesAndPlayers']);     
+        dataList.fuzzySearch($('#searchTerm').val(),['Title','Summary','AgenciesAndPlayers']);     
         megaFilter();
       });
       $('#stateSelect, #fedSelect, #dateStart, #dateEnd, #typeSelect, #topicSelect').on('change', function(e){
         e.preventDefault();
         megaFilter();
       });
+
+      $(document).ready(function(){
+        $(document).on('click', '.compBill', function(){
+          var compBill = $(this).text();
+          // console.log(compBill);
+          compBillData = dataList.get('Title',compBill)
+          console.log(compBillData.values().Title);
+          $('#companionBill').empty();
+          $('#companionBill').html(
+          `
+          <p>html injected</p>
+          <h5 class='card-title ml-3'>${compBillData.values().AgencyOrState}</h5>
+          `
+          );
+          });
+        });
 
       function megaFilter(){
 
@@ -499,7 +532,7 @@
           info.data.map((item)=>{
               item = item.map(str => str.trim());
               dataList.add({
-                  Title: item[1], 
+                  Title: item[2], 
                   AgencyOrState: item[0], 
                   Date: item[5], 
                   ActionType: item[3], 

--- a/public/index.html
+++ b/public/index.html
@@ -360,10 +360,9 @@
                               <div id='collapseFive${values.ID}' class='collapse' data-parent='#accordion${values.ID}'> 
                                 <div class='card-body'> 
                                   <h6><p>Primary Sources:</p></h6> 
-                                  <p><a ${(values.primarySources == 'N/A') ? '':`href=${values.primarySources} class='link-underline-primary' target='_blank'`}>${values.primarySources}<!--***primary sources links goes here and in href***--></a></p> 
+                                  <p>${(values.primarySources == 'N/A' || values.primarySources == undefined) ? 'N/A':`<a href=${values.primarySources} class='link-underline-primary' target='_blank'>${values.primarySources}<!--***primary sources links goes here and in href***--></a>`}</p> 
                                   <h6><p>Other Impotant Sources:</p></h6> 
-                                  <p><a ${(values.secondarySources == 'N/A') ? '':`href=${values.secondarySources} class='link-underline-primary' target='_blank'`}>${values.secondarySources}<!--***other important sources links goes here and in href***--></a></p> 
-                                </div> 
+                                  <p>${(values.secondarySources == 'N/A' || values.secondarySources == undefined) ? 'N/A':`<a href=${values.secondarySources} class='link-underline-primary' target='_blank'>${values.secondarySources}<!--***primary sources links goes here and in href***--></a>`}</p>                                 </div> 
                               </div> 
                           </div> 
                       </div> 
@@ -436,14 +435,14 @@
       $(document).ready(function(){
         $(document).on('click', '.compBill', function(){
           var compBill = $(this).text();
-          // console.log(compBill);
-          compBillData = dataList.get('Title',compBill)
+          console.log(compBill);
+          compBillData = dataList.get('Title',compBill);
           console.log(compBillData.values().Title);
           $('#companionBill').empty();
           $('#companionBill').html(
           `
           <p>html injected</p>
-          <h5 class='card-title ml-3'>${compBillData.values().AgencyOrState}</h5>
+          <h5 class='card-title ml-3'>Title: ${compBillData.values().Title}</h5>
           `
           );
           });

--- a/public/index.html
+++ b/public/index.html
@@ -271,7 +271,7 @@
           "AgenciesAndPlayers", 
           "Summary", 
           "Legislative", 
-          "CompanionBills", 
+          "CompanionBill", 
           "PFASDef", 
           "Sources",
           "ID"
@@ -330,14 +330,14 @@
                                   ${values.Legislative}
                               </div> 
                             </div> 
-                            <!--Companion Bills--> 
+                            <!--Companion Bill--> 
                             <div class='card'> 
                               <a class='card-link card-header' data-toggle='collapse' href='#collapseThree${values.ID}' > 
-                                Companion Bills 
+                                Companion Bill 
                               </a> 
                               <div id='collapseThree${values.ID}' class='collapse' data-parent='#accordion${values.ID}'> 
                                 <div class='card-body'>
-                                  ${values.CompanionBills == 'N/A' ? 'N/A':`<p><a class='compBill' href='#compBillModal' data-bs-toggle='modal'>${values.CompanionBills}</a></p>`}
+                                  ${(values.CompanionBill == 'N/A') || (values.CompanionBill == 'No companion legislation') ? 'N/A':`<p><a class='compBill' href='#compBillModal' data-bs-toggle='modal'>${values.CompanionBill}</a></p>`}
                               </div>
                             </div> 
                             <!--PFAS Definition--> 
@@ -432,17 +432,113 @@
         megaFilter();
       });
 
-      $(document).ready(function(){
+      $(document).ready(function(){ // companion bill event listener
         $(document).on('click', '.compBill', function(){
           var compBill = $(this).text();
-          console.log(compBill);
-          compBillData = dataList.get('Title',compBill);
-          console.log(compBillData.values().Title);
+          // console.log(compBill);
+          compBillVals = dataList.get('Title',compBill)[0].values();
+          // console.log(compBillData.values().Title);
+          // compBillVals = compBillData.values();
           $('#companionBill').empty();
           $('#companionBill').html(
           `
-          <p>html injected</p>
-          <h5 class='card-title ml-3'>Title: ${compBillData.values().Title}</h5>
+          <div class='card border-0'>  
+                  <div class='card-body'> 
+                      <h2 class='card-title ml-3'>  
+                      ${compBillVals.Title}
+              <!--***Name of Governance Action/title goes here***--> 
+                          <!--download button--> 
+                          <button type='button' class='btn btn-secondary'> 
+                              <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-download' viewBox='0 0 16 16'> 
+                          <path d='M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z'></path> 
+                          <path d='M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z'></path> 
+                            </svg> 
+                            </button> 
+                      </h2> 
+                      <!--Actor, Date, Legislation, Topics of Action, and Key Agencies/Players--> 
+                      <h5 class='card-actor ml-3'>Federal Agency or State:  
+              ${compBillVals.AgencyOrState} 
+              <!--***Name of Federal Agency/State goes here***--></h5> 
+                      <h5 class='card-date ml-3'>Date:  
+              ${compBillVals.Date}
+              <!--***Date of governance goes here***--></h5> 
+                      <h5 class='card-type ml-3'>Type of Governance Action:  
+              ${compBillVals.ActionType} 
+              <!--***Type of governance action goes here***--></h5> 
+                      <h5 class='card-topicsOfAction ml-3'>Topics of Governance Action:  
+              ${compBillVals.ActionTopic}
+              <!--***Topics of action goes here***--></h5> 
+                      <h5 class='card-keyAgencyPlayers ml-3'>Key Agencies and Players:  
+              ${compBillVals.AgenciesAndPlayers} 
+              <!--***Key agencies/players goes here***--></h5> 
+                        <!--Accordion${(compBillVals.ID).toString() + "modal"}Info Start--> 
+                        <div class='container mt-4'> 
+                          <div id='accordion${(compBillVals.ID).toString() + "modal"}'> 
+                          <!--Summary of Action--> 
+                            <div class='card'> 
+                              <a class='card-link card-header' data-toggle='collapse' href='#collapseOne${(compBillVals.ID).toString() + "modal"}' > 
+                                Summary of Action 
+                              </a> 
+                              <div id='collapseOne${(compBillVals.ID).toString() + "modal"}' class='collapse' data-parent='#accordion${(compBillVals.ID).toString() + "modal"}'> 
+                                <div class='card-body'> 
+                                  ${compBillVals.Summary}
+                              </div> 
+                            </div> 
+                            <!--Legislative outcome--> 
+                            <div class='card'> 
+                              <a class='card-link card-header' data-toggle='collapse' href='#collapseTwo${(compBillVals.ID).toString() + "modal"}' > 
+                                Legislative Outcome 
+                              </a> 
+                              <div id='collapseTwo${(compBillVals.ID).toString() + "modal"}' class='collapse' data-parent='#accordion${(compBillVals.ID).toString() + "modal"}'> 
+                                <div class='card-body'>   
+                                  ${compBillVals.Legislative}
+                              </div> 
+                            </div> 
+                            <!--Companion Bill--> 
+                            <div class='card'> 
+                              <a class='card-link card-header' data-toggle='collapse' href='#collapseThree${(compBillVals.ID).toString() + "modal"}' > 
+                                Companion Bill 
+                              </a> 
+                              <div id='collapseThree${(compBillVals.ID).toString() + "modal"}' class='collapse' data-parent='#accordion${(compBillVals.ID).toString() + "modal"}'> 
+                                <div class='card-body'>
+                                  ${(compBillVals.CompanionBill == 'N/A') || (compBillVals.CompanionBill == 'No companion legislation') ? 'N/A':`<p><a class='compBill' href='#compBillModal' data-bs-toggle='modal'>${compBillVals.CompanionBill}</a></p>`}
+                              </div>
+                            </div> 
+                            <!--PFAS Definition--> 
+                            <div class='card'> 
+                              <a class='collapsed card-link card-header' data-toggle='collapse' href='#collapseFour${(compBillVals.ID).toString() + "modal"}'> 
+                                PFAS Definition 
+                              </a> 
+                              <div id='collapseFour${(compBillVals.ID).toString() + "modal"}' class='collapse' data-parent='#accordion${(compBillVals.ID).toString() + "modal"}'> 
+                                <div class='card-body'>
+                                  ${compBillVals.PFASDef}
+                                  <!--***PFAS definition goes here***--> 
+                                </div> 
+                              </div> 
+                            </div> 
+                            <!--Sources--> 
+                            <div class='card'> 
+                              <a class='card-link card-header' data-toggle='collapse' href='#collapseFive${(compBillVals.ID).toString() + "modal"}'> 
+                                Sources 
+                              </a> 
+                              <div id='collapseFive${(compBillVals.ID).toString() + "modal"}' class='collapse' data-parent='#accordion${(compBillVals.ID).toString() + "modal"}'> 
+                                <div class='card-body'> 
+                                  <h6><p>Primary Sources:</p></h6> 
+                                  <p>${(compBillVals.primarySources == 'N/A' || compBillVals.primarySources == undefined) ? 'N/A':`<a href=${compBillVals.primarySources} class='link-underline-primary' target='_blank'>${compBillVals.primarySources}<!--***primary sources links goes here and in href***--></a>`}</p> 
+                                  <h6><p>Other Impotant Sources:</p></h6> 
+                                  <p>${(compBillVals.secondarySources == 'N/A' || compBillVals.secondarySources == undefined) ? 'N/A':`<a href=${compBillVals.secondarySources} class='link-underline-primary' target='_blank'>${compBillVals.secondarySources}<!--***primary sources links goes here and in href***--></a>`}</p>                                 </div> 
+                              </div> 
+                          </div> 
+                      </div> 
+                  </div> 
+              </div> 
+              </div> 
+              </div> 
+              </div> 
+              </div> 
+              </div> 
+              </div> 
+              </div> 
           `
           );
           });
@@ -539,7 +635,7 @@
                   AgenciesAndPlayers: item[10], 
                   Summary: item[9], 
                   Legislative: item[7], 
-                  CompanionBills: item[8], 
+                  CompanionBill: item[8], 
                   PFASDef: item[11], 
                   primarySources: item[12],
                   secondarySources: item[13],

--- a/public/index.html
+++ b/public/index.html
@@ -261,24 +261,9 @@
       <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/2.3.1/list.min.js" crossorigin="anonymous" type="text/javascript"></script>
       <script>
       var accordionID = 0;
-      var options = { // list.js options, fill with html template and column names
-          valueNames: [
-          "Title", 
-          "AgencyOrState", 
-          "Date", 
-          "ActionType", 
-          "ActionTopic", 
-          "AgenciesAndPlayers", 
-          "Summary", 
-          "Legislative", 
-          "CompanionBill", 
-          "PFASDef", 
-          "Sources",
-          "ID"
-      ],
-          item:
-              function (values){
-                  return `<div class='card'>  
+      function template(values, modal = false){
+      return `
+      <div class='card ${(modal ? "border-0":"")}'>  
                   <div class='card-body'> 
                       <h2 class='card-title ml-3'>  
                       ${values.Title}
@@ -307,45 +292,45 @@
                       <h5 class='card-keyAgencyPlayers ml-3'>Key Agencies and Players:  
               ${values.AgenciesAndPlayers} 
               <!--***Key agencies/players goes here***--></h5> 
-                        <!--Accordion${values.ID}Info Start--> 
+                        <!--Accordion${(values.ID.toString()) + (modal ? "modal":"")}Info Start--> 
                         <div class='container mt-4'> 
-                          <div id='accordion${values.ID}'> 
+                          <div id='accordion${(values.ID.toString()) + (modal ? "modal":"")}'> 
                           <!--Summary of Action--> 
                             <div class='card'> 
-                              <a class='card-link card-header' data-toggle='collapse' href='#collapseOne${values.ID}' > 
+                              <a class='card-link card-header' data-toggle='collapse' href='#collapseOne${(values.ID.toString()) + (modal ? "modal":"")}' > 
                                 Summary of Action 
                               </a> 
-                              <div id='collapseOne${values.ID}' class='collapse' data-parent='#accordion${values.ID}'> 
+                              <div id='collapseOne${(values.ID.toString()) + (modal ? "modal":"")}' class='collapse' data-parent='#accordion${(values.ID.toString()) + (modal ? "modal":"")}'> 
                                 <div class='card-body'> 
                                   ${values.Summary}
                               </div> 
                             </div> 
                             <!--Legislative outcome--> 
                             <div class='card'> 
-                              <a class='card-link card-header' data-toggle='collapse' href='#collapseTwo${values.ID}' > 
+                              <a class='card-link card-header' data-toggle='collapse' href='#collapseTwo${(values.ID.toString()) + (modal ? "modal":"")}' > 
                                 Legislative Outcome 
                               </a> 
-                              <div id='collapseTwo${values.ID}' class='collapse' data-parent='#accordion${values.ID}'> 
+                              <div id='collapseTwo${(values.ID.toString()) + (modal ? "modal":"")}' class='collapse' data-parent='#accordion${(values.ID.toString()) + (modal ? "modal":"")}'> 
                                 <div class='card-body'>   
                                   ${values.Legislative}
                               </div> 
                             </div> 
                             <!--Companion Bill--> 
                             <div class='card'> 
-                              <a class='card-link card-header' data-toggle='collapse' href='#collapseThree${values.ID}' > 
+                              <a class='card-link card-header' data-toggle='collapse' href='#collapseThree${(values.ID.toString()) + (modal ? "modal":"")}' > 
                                 Companion Bill 
                               </a> 
-                              <div id='collapseThree${values.ID}' class='collapse' data-parent='#accordion${values.ID}'> 
+                              <div id='collapseThree${(values.ID.toString()) + (modal ? "modal":"")}' class='collapse' data-parent='#accordion${(values.ID.toString()) + (modal ? "modal":"")}'> 
                                 <div class='card-body'>
                                   ${(values.CompanionBill == 'N/A') || (values.CompanionBill == 'No companion legislation') ? 'N/A':`<p><a class='compBill' href='#compBillModal' data-bs-toggle='modal'>${values.CompanionBill}</a></p>`}
                               </div>
                             </div> 
                             <!--PFAS Definition--> 
                             <div class='card'> 
-                              <a class='collapsed card-link card-header' data-toggle='collapse' href='#collapseFour${values.ID}'> 
+                              <a class='collapsed card-link card-header' data-toggle='collapse' href='#collapseFour${(values.ID.toString()) + (modal ? "modal":"")}'> 
                                 PFAS Definition 
                               </a> 
-                              <div id='collapseFour${values.ID}' class='collapse' data-parent='#accordion${values.ID}'> 
+                              <div id='collapseFour${(values.ID.toString()) + (modal ? "modal":"")}' class='collapse' data-parent='#accordion${(values.ID.toString()) + (modal ? "modal":"")}'> 
                                 <div class='card-body'>
                                   ${values.PFASDef}
                                   <!--***PFAS definition goes here***--> 
@@ -354,10 +339,10 @@
                             </div> 
                             <!--Sources--> 
                             <div class='card'> 
-                              <a class='card-link card-header' data-toggle='collapse' href='#collapseFive${values.ID}'> 
+                              <a class='card-link card-header' data-toggle='collapse' href='#collapseFive${(values.ID.toString()) + (modal ? "modal":"")}'> 
                                 Sources 
                               </a> 
-                              <div id='collapseFive${values.ID}' class='collapse' data-parent='#accordion${values.ID}'> 
+                              <div id='collapseFive${(values.ID.toString()) + (modal ? "modal":"")}' class='collapse' data-parent='#accordion${(values.ID.toString()) + (modal ? "modal":"")}'> 
                                 <div class='card-body'> 
                                   <h6><p>Primary Sources:</p></h6> 
                                   <p>${(values.primarySources == 'N/A' || values.primarySources == undefined) ? 'N/A':`<a href=${values.primarySources} class='link-underline-primary' target='_blank'>${values.primarySources}<!--***primary sources links goes here and in href***--></a>`}</p> 
@@ -374,7 +359,27 @@
               </div> 
               </div> 
               </div> 
-              </div> ` ;
+              </div> 
+      `;
+      };
+      var options = { // list.js options, fill with html template and column names
+          valueNames: [
+          "Title", 
+          "AgencyOrState", 
+          "Date", 
+          "ActionType", 
+          "ActionTopic", 
+          "AgenciesAndPlayers", 
+          "Summary", 
+          "Legislative", 
+          "CompanionBill", 
+          "PFASDef", 
+          "Sources",
+          "ID"
+      ],
+          item:
+              function (values){
+                return template(values);
               }
       };
       var values = []; // list.js values (should stay empty)
@@ -441,105 +446,7 @@
           // compBillVals = compBillData.values();
           $('#companionBill').empty();
           $('#companionBill').html(
-          `
-          <div class='card border-0'>  
-                  <div class='card-body'> 
-                      <h2 class='card-title ml-3'>  
-                      ${compBillVals.Title}
-              <!--***Name of Governance Action/title goes here***--> 
-                          <!--download button--> 
-                          <button type='button' class='btn btn-secondary'> 
-                              <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-download' viewBox='0 0 16 16'> 
-                          <path d='M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z'></path> 
-                          <path d='M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z'></path> 
-                            </svg> 
-                            </button> 
-                      </h2> 
-                      <!--Actor, Date, Legislation, Topics of Action, and Key Agencies/Players--> 
-                      <h5 class='card-actor ml-3'>Federal Agency or State:  
-              ${compBillVals.AgencyOrState} 
-              <!--***Name of Federal Agency/State goes here***--></h5> 
-                      <h5 class='card-date ml-3'>Date:  
-              ${compBillVals.Date}
-              <!--***Date of governance goes here***--></h5> 
-                      <h5 class='card-type ml-3'>Type of Governance Action:  
-              ${compBillVals.ActionType} 
-              <!--***Type of governance action goes here***--></h5> 
-                      <h5 class='card-topicsOfAction ml-3'>Topics of Governance Action:  
-              ${compBillVals.ActionTopic}
-              <!--***Topics of action goes here***--></h5> 
-                      <h5 class='card-keyAgencyPlayers ml-3'>Key Agencies and Players:  
-              ${compBillVals.AgenciesAndPlayers} 
-              <!--***Key agencies/players goes here***--></h5> 
-                        <!--Accordion${(compBillVals.ID).toString() + "modal"}Info Start--> 
-                        <div class='container mt-4'> 
-                          <div id='accordion${(compBillVals.ID).toString() + "modal"}'> 
-                          <!--Summary of Action--> 
-                            <div class='card'> 
-                              <a class='card-link card-header' data-toggle='collapse' href='#collapseOne${(compBillVals.ID).toString() + "modal"}' > 
-                                Summary of Action 
-                              </a> 
-                              <div id='collapseOne${(compBillVals.ID).toString() + "modal"}' class='collapse' data-parent='#accordion${(compBillVals.ID).toString() + "modal"}'> 
-                                <div class='card-body'> 
-                                  ${compBillVals.Summary}
-                              </div> 
-                            </div> 
-                            <!--Legislative outcome--> 
-                            <div class='card'> 
-                              <a class='card-link card-header' data-toggle='collapse' href='#collapseTwo${(compBillVals.ID).toString() + "modal"}' > 
-                                Legislative Outcome 
-                              </a> 
-                              <div id='collapseTwo${(compBillVals.ID).toString() + "modal"}' class='collapse' data-parent='#accordion${(compBillVals.ID).toString() + "modal"}'> 
-                                <div class='card-body'>   
-                                  ${compBillVals.Legislative}
-                              </div> 
-                            </div> 
-                            <!--Companion Bill--> 
-                            <div class='card'> 
-                              <a class='card-link card-header' data-toggle='collapse' href='#collapseThree${(compBillVals.ID).toString() + "modal"}' > 
-                                Companion Bill 
-                              </a> 
-                              <div id='collapseThree${(compBillVals.ID).toString() + "modal"}' class='collapse' data-parent='#accordion${(compBillVals.ID).toString() + "modal"}'> 
-                                <div class='card-body'>
-                                  ${(compBillVals.CompanionBill == 'N/A') || (compBillVals.CompanionBill == 'No companion legislation') ? 'N/A':`<p><a class='compBill' href='#compBillModal' data-bs-toggle='modal'>${compBillVals.CompanionBill}</a></p>`}
-                              </div>
-                            </div> 
-                            <!--PFAS Definition--> 
-                            <div class='card'> 
-                              <a class='collapsed card-link card-header' data-toggle='collapse' href='#collapseFour${(compBillVals.ID).toString() + "modal"}'> 
-                                PFAS Definition 
-                              </a> 
-                              <div id='collapseFour${(compBillVals.ID).toString() + "modal"}' class='collapse' data-parent='#accordion${(compBillVals.ID).toString() + "modal"}'> 
-                                <div class='card-body'>
-                                  ${compBillVals.PFASDef}
-                                  <!--***PFAS definition goes here***--> 
-                                </div> 
-                              </div> 
-                            </div> 
-                            <!--Sources--> 
-                            <div class='card'> 
-                              <a class='card-link card-header' data-toggle='collapse' href='#collapseFive${(compBillVals.ID).toString() + "modal"}'> 
-                                Sources 
-                              </a> 
-                              <div id='collapseFive${(compBillVals.ID).toString() + "modal"}' class='collapse' data-parent='#accordion${(compBillVals.ID).toString() + "modal"}'> 
-                                <div class='card-body'> 
-                                  <h6><p>Primary Sources:</p></h6> 
-                                  <p>${(compBillVals.primarySources == 'N/A' || compBillVals.primarySources == undefined) ? 'N/A':`<a href=${compBillVals.primarySources} class='link-underline-primary' target='_blank'>${compBillVals.primarySources}<!--***primary sources links goes here and in href***--></a>`}</p> 
-                                  <h6><p>Other Impotant Sources:</p></h6> 
-                                  <p>${(compBillVals.secondarySources == 'N/A' || compBillVals.secondarySources == undefined) ? 'N/A':`<a href=${compBillVals.secondarySources} class='link-underline-primary' target='_blank'>${compBillVals.secondarySources}<!--***primary sources links goes here and in href***--></a>`}</p>                                 </div> 
-                              </div> 
-                          </div> 
-                      </div> 
-                  </div> 
-              </div> 
-              </div> 
-              </div> 
-              </div> 
-              </div> 
-              </div> 
-              </div> 
-              </div> 
-          `
+          template(compBillVals, true)
           );
           });
         });


### PR DESCRIPTION
implemented companion bill popup, shows info of companion bill in similar format to the cards. Also handles not linking when companion bills are either "N/A" or "no companion bill provided". Unsure or whether the popup should include the download button, but I kept It for consistency. I also changed the language of the cards and code to match the google sheet and refer to "companion bill" rather than "companion bills" because there aren't any bills with multiple companion bills.  