### PR TITLE
debugged reset filters to not overlap search bar

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -54,7 +54,7 @@ html, body {
       .sticky-top-filter {
          position: -webkit-sticky;
          position: sticky;
-         top: 70px;
+         top: 93px;
          z-index: 1019;
          }
      } 
@@ -115,6 +115,8 @@ html, body {
     margin-right: 5;
 
   }
+
+
     
     
     


### PR DESCRIPTION
reset all filters now doesn't not overlap the search bar