### PR TITLE
split up source links

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -416,9 +416,9 @@
                               <div id='collapseFive${(values.ID.toString()) + (modal ? "modal":"")}' class='collapse' data-parent='#accordion${(values.ID.toString()) + (modal ? "modal":"")}'> 
                                 <div class='card-body'> 
                                   <h6><p>Primary Sources:</p></h6> 
-                                  <p>${(values.PrimarySources == 'N/A' || values.PrimarySources == undefined) ? 'N/A':`<a href=${values.PrimarySources} class='link-underline-Primary' target='_blank'>${values.PrimarySources}<!--***primary sources links goes here and in href***--></a>`}</p> 
+                                  <p>${(values.PrimarySources == 'N/A' || values.PrimarySources == undefined) ? 'N/A': values.PrimarySources.split(', ').map((link)=>{return`<a href=${link} class='link-underline-Primary' target='_blank'>${link}</a> <br />`})}</p> 
                                   <h6><p>Other Important Sources:</p></h6> 
-                                  <p>${(values.SecondarySources == 'N/A' || values.SecondarySources == undefined) ? 'N/A':`<a href=${values.SecondarySources} class='link-underline-primary' target='_blank'>${values.SecondarySources}<!--***primary sources links goes here and in href***--></a>`}</p>                                 </div> 
+                                  <p>${(values.SecondarySources == 'N/A' || values.SecondarySources == undefined) ? 'N/A': values.SecondarySources.split(', ').map((link)=>{return`<a href=${link} class='link-underline-Primary' target='_blank'>${link}</a> <br />`})}</p> 
                               </div> 
                           </div> 
                       </div> 
@@ -682,6 +682,10 @@
               if (date > latestDate)    latestDate = date;
 
               item = item.map(str => str.trim());
+              if (item[13] != undefined){
+              if (item[13].split(',').length > 1) {
+                console.log(item[13].split(', '));
+              }}
               dataList.add({
                   Title: item[2], 
                   AgencyOrState: item[0], 

--- a/public/index.html
+++ b/public/index.html
@@ -415,10 +415,10 @@
                               </a> 
                               <div id='collapseFive${(values.ID.toString()) + (modal ? "modal":"")}' class='collapse' data-parent='#accordion${(values.ID.toString()) + (modal ? "modal":"")}'> 
                                 <div class='card-body'> 
-                                  <h6><p>Primary Sources:</p></h6> 
-                                  <p>${(values.PrimarySources == 'N/A' || values.PrimarySources == undefined) ? 'N/A': values.PrimarySources.split(', ').map((link)=>{return`<a href=${link} class='link-underline-Primary' target='_blank'>${link}</a> <br />`})}</p> 
+                                  <h6><p>Primary Source:</p></h6> 
+                                  <p><ul>${(values.PrimarySources == 'N/A' || values.PrimarySources == undefined) ? 'N/A': values.PrimarySources.split(', ').map((link)=>{return`<li><a href=${link} class='link-underline-Primary' target='_blank'>${link}</a></li> <br />`})}</ul></p> 
                                   <h6><p>Other Important Sources:</p></h6> 
-                                  <p>${(values.SecondarySources == 'N/A' || values.SecondarySources == undefined) ? 'N/A': values.SecondarySources.split(', ').map((link)=>{return`<a href=${link} class='link-underline-Primary' target='_blank'>${link}</a> <br />`})}</p> 
+                                  <p><ul>${(values.SecondarySources == 'N/A' || values.SecondarySources == undefined) ? 'N/A': values.SecondarySources.split(', ').map((link)=>{return`<li> <a href=${link} class='link-underline-Primary' target='_blank'>${link}</a></li> <br />`}).join('\n')}</ul></p> 
                               </div> 
                           </div> 
                       </div> 


### PR DESCRIPTION
split up links so that each link leads to its corresponding address. links are just displayed, separated by commas. 